### PR TITLE
Improve mobile form usability and card spacing

### DIFF
--- a/packages/web/src/components/transfers/simplified-off-ramp.tsx
+++ b/packages/web/src/components/transfers/simplified-off-ramp.tsx
@@ -460,7 +460,7 @@ export function SimplifiedOffRamp() {
         </CardDescription>
         <Progress value={(formStep / 3) * 100} className="mt-2" />
       </CardHeader>
-      <CardContent className="p-6">
+      <CardContent className="p-6 max-h-[70vh] overflow-y-auto">
         <form onSubmit={handleSubmit(handleInitiateSubmit)} className="space-y-6">
           {/* Step 1: Amount */}
           {formStep === 1 && (
@@ -534,7 +534,7 @@ export function SimplifiedOffRamp() {
                     <RadioGroup
                       onValueChange={field.onChange}
                       value={field.value}
-                      className="grid grid-cols-1 sm:grid-cols-2 gap-3"
+                      className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3"
                     >
                       <div className="relative">
                         <RadioGroupItem value="ach" id="ach" className="peer sr-only" />
@@ -589,7 +589,7 @@ export function SimplifiedOffRamp() {
                             "font-medium transition-colors",
                             destinationType === 'iban' ? "text-blue-900" : "text-gray-600"
                           )}>
-                            International
+                            EU
                           </span>
                           <span className={cn(
                             "text-xs mt-1 transition-colors",


### PR DESCRIPTION
I implemented several changes in `packages/web/src/components/transfers/simplified-off-ramp.tsx` to improve the mobile user experience:

*   I added `max-h-[70vh] overflow-y-auto` to the `CardContent` component. This ensures that the form content becomes scrollable on mobile devices when it exceeds the screen height, allowing users to access all fields and call-to-action buttons that were previously off-screen due to overflow.
*   I modified the `className` of the `RadioGroup` for transfer method selection from `gap-3` to `gap-2 sm:gap-3`. This reduces the spacing between the "US Bank" and "EU" cards on mobile screens (to an 8px gap) for a more compact layout, while preserving the original 12px gap on larger screens.
*   I updated the label for the international transfer option from "International" to "EU" to reflect the correct terminology.