### PR TITLE
Code GitHub issue number 168

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,7 +30,7 @@
     "setup:db": "dotenv -e .env.local -- tsx ./scripts/setup-neon-branch.ts"
   },
   "dependencies": {
-    "@ai-sdk/openai": "catalog:",
+    "@ai-sdk/openai": "^0.7.0",
     "@ai-sdk/react": "^1.2.12",
     "@hookform/resolvers": "catalog:",
     "@lifi/types": "^17.9.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,7 +30,7 @@
     "setup:db": "dotenv -e .env.local -- tsx ./scripts/setup-neon-branch.ts"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^0.7.0",
+    "@ai-sdk/openai": "^1.3.22",
     "@ai-sdk/react": "^1.2.12",
     "@hookform/resolvers": "catalog:",
     "@lifi/types": "^17.9.0",

--- a/packages/web/src/app/(authenticated)/dashboard/create-invoice/page.tsx
+++ b/packages/web/src/app/(authenticated)/dashboard/create-invoice/page.tsx
@@ -5,6 +5,7 @@ import { InvoiceForm } from '@/components/invoice/invoice-form';
 import { Toaster } from 'sonner';
 import { ClientDragPrevention } from '@/components/invoice/client-drag-prevention';
 import { AuthGuard } from '@/components/auth/auth-guard';
+import { RawTextPrefill } from '@/components/invoice/raw-text-prefill';
 
 export default function CreateInvoicePage() {
   // Reference to the invoice form
@@ -42,7 +43,11 @@ export default function CreateInvoicePage() {
               </div>
             </div>
             
-
+            {/* Raw Text Prefill - Right Side */}
+            <div className="w-[30%] max-w-md overflow-y-auto pb-8 pr-2">
+              {/* Spacer on small screens maybe hide? Use responsive classes if needed */}
+              <RawTextPrefill />
+            </div>
           </div>
         </div>
       </ClientDragPrevention>

--- a/packages/web/src/components/invoice/raw-text-prefill.tsx
+++ b/packages/web/src/components/invoice/raw-text-prefill.tsx
@@ -26,6 +26,8 @@ export function RawTextPrefill() {
     },
   });
 
+  const isBusy = (mutation as any).isLoading ?? (mutation as any).isPending ?? false;
+
   return (
     <div className="flex flex-col h-full w-full gap-3 p-4 border rounded-md bg-muted/40">
       <h2 className="font-semibold text-lg">Paste invoice description</h2>
@@ -36,10 +38,10 @@ export function RawTextPrefill() {
         onChange={(e) => setRawText(e.target.value)}
       />
       <Button
-        disabled={mutation.isLoading || rawText.trim().length < 10}
+        disabled={isBusy || rawText.trim().length < 10}
         onClick={() => mutation.mutate({ rawText })}
       >
-        {mutation.isLoading ? 'Parsing…' : 'AI Fill Invoice'}
+        {isBusy ? 'Parsing…' : 'AI Fill Invoice'}
       </Button>
     </div>
   );

--- a/packages/web/src/components/invoice/raw-text-prefill.tsx
+++ b/packages/web/src/components/invoice/raw-text-prefill.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { api as trpc } from '@/trpc/react';
+import { useInvoiceStore } from '@/lib/store/invoice-store';
+
+/**
+ * RawTextPrefill – allows user to paste unstructured invoice text and pre-fill the
+ * existing InvoiceForm via the AI endpoint.
+ */
+export function RawTextPrefill() {
+  const [rawText, setRawText] = useState('');
+  const setDetectedInvoiceData = useInvoiceStore((s) => s.setDetectedInvoiceData);
+  const applyDataToForm = useInvoiceStore((s) => s.applyDataToForm);
+
+  const mutation = trpc.invoice.prefillFromRaw.useMutation({
+    onSuccess: async (data) => {
+      setDetectedInvoiceData(data as any);
+      await applyDataToForm();
+      toast.success('Invoice form pre-filled – review & edit as needed!');
+    },
+    onError: (err) => {
+      console.error(err);
+      toast.error(err.message || 'Failed to parse invoice text');
+    },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full gap-3 p-4 border rounded-md bg-muted/40">
+      <h2 className="font-semibold text-lg">Paste invoice description</h2>
+      <Textarea
+        className="flex-1 resize-none min-h-[200px]"
+        placeholder="e.g. Invoice for 10 hours of design at $100/hr to Acme Corp, due in 30 days…"
+        value={rawText}
+        onChange={(e) => setRawText(e.target.value)}
+      />
+      <Button
+        disabled={mutation.isLoading || rawText.trim().length < 10}
+        onClick={() => mutation.mutate({ rawText })}
+      >
+        {mutation.isLoading ? 'Parsing…' : 'AI Fill Invoice'}
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/server/routers/invoice-router.ts
+++ b/packages/web/src/server/routers/invoice-router.ts
@@ -673,7 +673,7 @@ export const invoiceRouter = router({
 
       const openaiAny = myProvider as any;
       const chatResponse = await openaiAny.chat.completions.create({
-        model: 'gpt-4o',
+        model: 'gpt-4',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: rawText },

--- a/packages/web/src/server/routers/invoice-router.ts
+++ b/packages/web/src/server/routers/invoice-router.ts
@@ -672,9 +672,11 @@ export const invoiceRouter = router({
       const systemPrompt = `You are an API that converts unstructured invoice descriptions into JSON that matches the following TypeScript interface (keys may be omitted if data is not present):\n\ninterface AIInvoicePrefill {\n  sellerInfo?: { businessName?: string; email?: string };\n  buyerInfo?: { businessName?: string; email?: string };\n  invoiceItems?: Array<{ name: string; quantity: number; unitPrice: string }>;\n  currency?: string;\n  paymentTerms?: { dueDate?: string } | string;\n  note?: string;\n}\n\nReturn ONLY valid minified JSON with no extra keys, comments or markdown. Dates should be ISO-8601 (YYYY-MM-DD). Monetary values as strings.`;
 
       // Using Vercel AI SDK utilities
-      const { generateText } = await import('ai');
+      const aiModule = await import('ai');
+      const generateText = aiModule.generateText;
 
-      const chatModel: any = (myProvider as any).chat('gpt-4.1-mini', {
+      // `chat` returns a properly-typed ChatModel; TypeScript infers the type.
+      const chatModel = myProvider.chat('gpt-4.1-mini', {
         temperature: 0.2,
       });
 

--- a/packages/web/src/server/routers/invoice-router.ts
+++ b/packages/web/src/server/routers/invoice-router.ts
@@ -673,7 +673,7 @@ export const invoiceRouter = router({
 
       const openaiAny = myProvider as any;
       const chatResponse = await openaiAny.chat.completions.create({
-        model: 'gpt-4',
+        model: 'gpt-4.1-mini',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: rawText },

--- a/packages/web/src/server/routers/invoice-router.ts
+++ b/packages/web/src/server/routers/invoice-router.ts
@@ -673,7 +673,7 @@ export const invoiceRouter = router({
 
       const openaiAny = myProvider as any;
       const chatResponse = await openaiAny.chat.completions.create({
-        model: 'gpt-4.1-mini',
+        model: 'gpt-4o-mini',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: rawText },

--- a/packages/web/src/server/routers/invoice-router.ts
+++ b/packages/web/src/server/routers/invoice-router.ts
@@ -673,7 +673,7 @@ export const invoiceRouter = router({
 
       const openaiAny = myProvider as any;
       const chatResponse = await openaiAny.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: 'gpt-4o',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: rawText },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@ai-sdk/openai':
-      specifier: 1.3.22
-      version: 1.3.22
     '@hookform/resolvers':
       specifier: ^3.9.0
       version: 3.10.0
@@ -181,7 +178,7 @@ importers:
   packages/web:
     dependencies:
       '@ai-sdk/openai':
-        specifier: 'catalog:'
+        specifier: ^1.3.22
         version: 1.3.22(zod@3.25.49)
       '@ai-sdk/react':
         specifier: ^1.2.12


### PR DESCRIPTION
An AI-powered raw text prefill feature was implemented for invoices.

*   A new `RawTextPrefill` component was created in `packages/web/src/components/invoice/raw-text-prefill.tsx`. It provides a textarea for raw text input and a button to trigger AI parsing.
*   The `create-invoice/page.tsx` layout was updated to integrate `RawTextPrefill` alongside the existing invoice form.
*   A `prefillFromRaw` tRPC mutation was added to `invoice-router.ts`. This mutation uses an AI provider (initially `gpt-4.1-mini`, later updated to `gpt-4o-mini`, then `gpt-4o`, and finally `gpt-4`) to convert unstructured text into structured JSON, loosely validated against `invoiceDataSchema`.
*   Client-side, the `RawTextPrefill` component now uses the `prefillFromRaw` mutation to fetch parsed data, which is then applied to the invoice form via `zustand`'s `setDetectedInvoiceData` and `applyDataToForm`.
*   TypeScript errors in `raw-text-prefill.tsx` were resolved by introducing an `isBusy` flag that checks both `isLoading` and `isPending` properties of the tRPC mutation, updating button state logic accordingly.
*   The OpenAI model name in `invoice-router.ts` was iteratively updated from an initial placeholder to `gpt-4o-mini`, then `gpt-4o`, and finally `gpt-4` to ensure a valid and supported model is used.