### PR TITLE
Prevent bug occurrence with update

### DIFF
--- a/packages/web/src/server/routers/user-router.ts
+++ b/packages/web/src/server/routers/user-router.ts
@@ -90,20 +90,20 @@ export const userRouter = router({
       try {
         // 2. Call Loops API to create or update contact
         const response = await fetch(
-          'https://app.loops.so/api/v1/contacts/create',
+          'https://app.loops.so/api/v1/contacts/update',
           {
-            // or /update if preferred
-            method: 'POST',
+            method: 'PUT',
             headers: {
               Authorization: `Bearer ${loopsApiKey}`,
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
               email: email,
-              userId: privyUserId, // Use Privy ID as the Loops userId
+              userId: privyUserId, // Use Privy ID as the Loops userId (acts as stable identifier)
               firstName: name?.split(' ')[0] ?? '',
               source: 'zero finance app sync',
-              joinedAt: new Date().toISOString(),
+              subscribed: true,
+              // Loops ignores unknown fields so joinedAt is not required ‑ keep payload minimal
             }),
           },
         );


### PR DESCRIPTION
A more resilient Loops contact synchronization was implemented.

Key changes:
*   In `packages/web/src/server/routers/user-router.ts`, the Loops API call was updated.
*   The endpoint was changed from `https://app.loops.so/api/v1/contacts/create` to `https://app.loops.so/api/v1/contacts/update`.
*   The HTTP method was changed from `POST` to `PUT`.
*   The request body now includes `subscribed: true` and omits `joinedAt`.

Reasoning:
*   The `PUT /update` endpoint in Loops functions as an upsert operation. It creates a contact if it doesn't exist or updates it if it does.
*   This change prevents the 409 "Email or userId is already on list" conflict that occurred with the `POST /create` endpoint when a contact already existed.
*   Adding `subscribed: true` ensures the contact is marked as subscribed.
*   Removing `joinedAt` keeps the payload minimal, as it's not required by the `update` endpoint.

Behavior:
*   Existing users already present in Loops will now be updated seamlessly without triggering errors.
*   The `loopsContactSynced` flag continues to be set only after a successful API response.