### PR TITLE
feat: Track manual deposits in Recent Activity

### DIFF
--- a/packages/web/src/app/(authenticated)/dashboard/savings/page.tsx
+++ b/packages/web/src/app/(authenticated)/dashboard/savings/page.tsx
@@ -613,7 +613,7 @@ export default function SavingsPage() {
                             <div>
                               <p className="text-sm font-medium">
                                 {tx.type === 'deposit'
-                                  ? 'Auto-save'
+                                  ? (tx.depositPercentage ? 'Auto-save' : 'Manual Deposit')
                                   : 'Withdrawal'}
                               </p>
                               <p className="text-xs text-muted-foreground">
@@ -636,7 +636,7 @@ export default function SavingsPage() {
                                   : tx.amount,
                               )}
                             </p>
-                            {tx.type === 'deposit' && tx.skimmedAmount && (
+                            {tx.type === 'deposit' && tx.skimmedAmount && tx.depositPercentage && (
                               <p className="text-xs text-muted-foreground">
                                 From {formatUsd(tx.amount)} deposit
                               </p>

--- a/packages/web/src/components/savings/savings-panel.tsx
+++ b/packages/web/src/components/savings/savings-panel.tsx
@@ -105,7 +105,7 @@ export default function SavingsPanel({
     // add a card around the content
     <div className="w-full space-y-6">
       <div className="bg-white p-6 rounded-card-lg shadow-premium-subtle">
-        <div className="w-full max-w-lg space-y-6">
+        <div className="w-full space-y-6">
       {/* Header */}
       <div className="text-center">
         <div className="inline-flex items-center justify-center w-14 h-14 bg-primary/10 rounded-full mb-4">


### PR DESCRIPTION
## Summary
- Adds tracking for manual deposits made through the app
- Differentiates between "Manual Deposit" and "Auto-save" in Recent Activity
- Stores manual deposits in the database for immediate display

## Problem
Previously, the Recent Activity section only showed auto-save transactions. Manual deposits made through the deposit card were not being tracked or displayed, making it difficult for users to see their complete transaction history.

## Solution
- Added `recordManualDeposit` tRPC mutation to store manual deposits with `depositPercentage: null`
- Updated `DepositEarnCard` to call the mutation after successful deposits
- Modified Recent Activity display to show "Manual Deposit" vs "Auto-save" based on the presence of `depositPercentage`
- Manual deposits show the full deposited amount without the "From $X deposit" subtitle

## Testing
1. Make a manual deposit through the deposit card
2. Check that it appears in Recent Activity as "Manual Deposit"
3. Verify auto-saves still show as "Auto-save" with the percentage info

🤖 Generated with [Claude Code](https://claude.ai/code)