### PR TITLE
Guarantee embedded wallet provisioning on dashboard

### DIFF
--- a/packages/web/src/app/(authenticated)/dashboard/dashboard-client-layout.tsx
+++ b/packages/web/src/app/(authenticated)/dashboard/dashboard-client-layout.tsx
@@ -11,6 +11,7 @@ import {
 import { usePhoneCollection } from '@/hooks/use-phone-collection';
 import { useAutoSafeCreation } from '@/hooks/use-auto-safe-creation';
 import { InviteHandler } from '@/components/auth/invite-handler';
+import { EnsureEmbeddedWallet } from '@/components/auth/ensure-embedded-wallet';
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 
@@ -69,6 +70,7 @@ export default function DashboardClientLayout({
 
   return (
     <>
+      <EnsureEmbeddedWallet />
       <InviteHandler />
       <div className="flex h-screen bg-[#F7F7F2]">
         {/* Mobile sidebar - shown only when mobileMenuOpen is true */}

--- a/packages/web/src/components/auth/ensure-embedded-wallet.tsx
+++ b/packages/web/src/components/auth/ensure-embedded-wallet.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import {
+  usePrivy,
+  useWallets,
+  useCreateWallet,
+} from '@privy-io/react-auth';
+
+/**
+ * Guarantees that a user has an embedded Privy wallet provisioned after login.
+ * Useful when the Privy modal is not the primary login flow.
+ */
+export function EnsureEmbeddedWallet() {
+  const { ready, authenticated } = usePrivy();
+  const { wallets } = useWallets();
+  const { createWallet, creatingWallet } = useCreateWallet();
+
+  useEffect(() => {
+    if (!ready || !authenticated || creatingWallet) return;
+
+    const hasEmbedded = wallets.some(
+      (wallet) => wallet.walletClientType === 'privy',
+    );
+
+    if (!hasEmbedded) {
+      void createWallet();
+    }
+  }, [ready, authenticated, wallets, createWallet, creatingWallet]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add EnsureEmbeddedWallet guard that provisions a Privy embedded wallet after login
- mount the guard in the dashboard client layout so every authenticated session links an EOA

## Testing
- pnpm --filter @zero-finance/web lint