### PR TITLE
feat: Make auto-earn module optional for new users

### DIFF
--- a/packages/web/src/app/(authenticated)/dashboard/savings/page-wrapper.tsx
+++ b/packages/web/src/app/(authenticated)/dashboard/savings/page-wrapper.tsx
@@ -1114,105 +1114,8 @@ export default function SavingsPageWrapper({
 
   return (
     <div className="space-y-10">
-      {/* Not Initialized State */}
-      {!isEarnModuleInitialized ? (
-        isDemoMode ? (
-          isActivatingDemo ? (
-            <div className="bg-white border border-[#101010]/10 p-12">
-              <div className="max-w-md mx-auto space-y-8">
-                <div className="flex justify-center">
-                  <div className="relative">
-                    <div className="absolute inset-0 bg-[#1B29FF]/20 rounded-full animate-ping" />
-                    <div className="relative bg-[#1B29FF]/10 rounded-full p-4">
-                      <Sparkles className="h-8 w-8 text-[#1B29FF] animate-pulse" />
-                    </div>
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  <h3 className="font-serif text-[24px] text-center text-[#101010]">
-                    Activating Your Savings
-                  </h3>
-
-                  <div className="space-y-3">
-                    {activationSteps.map((step, index) => (
-                      <div
-                        key={step}
-                        className="flex items-center gap-3 transition-all duration-300"
-                        style={{
-                          opacity: index <= activationStep ? 1 : 0.3,
-                          transform:
-                            index <= activationStep
-                              ? 'translateX(0)'
-                              : 'translateX(-10px)',
-                        }}
-                      >
-                        <div className="flex-shrink-0">
-                          {index < activationStep ? (
-                            <CheckCircle2 className="h-5 w-5 text-green-500" />
-                          ) : index === activationStep ? (
-                            <div className="h-5 w-5 border-2 border-[#1B29FF] rounded-full border-t-transparent animate-spin" />
-                          ) : (
-                            <div className="h-5 w-5 border-2 border-[#101010]/20 rounded-full" />
-                          )}
-                        </div>
-                        <span
-                          className={`text-[14px] ${index <= activationStep ? 'text-[#101010]' : 'text-[#101010]/40'}`}
-                        >
-                          {step}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-
-                  <div className="relative h-2 bg-[#101010]/5 rounded-full overflow-hidden">
-                    <div
-                      className="absolute inset-y-0 left-0 bg-gradient-to-r from-[#1B29FF] to-[#1B29FF]/80 rounded-full transition-all duration-500 ease-out"
-                      style={{
-                        width: `${((activationStep + 1) / activationSteps.length) * 100}%`,
-                      }}
-                    >
-                      <div className="absolute inset-0 bg-white/30 animate-shimmer" />
-                    </div>
-                  </div>
-
-                  <p className="text-center text-[12px] text-[#101010]/50">
-                    Setting up your high-yield savings account...
-                  </p>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="bg-white border border-[#101010]/10 p-12 text-center">
-              <Wallet className="h-12 w-12 text-[#101010]/40 mx-auto mb-6" />
-              <h2 className="font-serif text-[36px] leading-[1.1] text-[#101010] mb-3">
-                Activate Savings Account
-              </h2>
-              <p className="text-[16px] text-[#101010]/70 mb-8 max-w-[400px] mx-auto">
-                Start earning up to 8% APY on your business funds.
-              </p>
-              <Button
-                onClick={handleDemoActivate}
-                className="bg-[#1B29FF] hover:bg-[#1B29FF]/90 transition-all hover:scale-[1.02]"
-              >
-                Activate Savings
-              </Button>
-            </div>
-          )
-        ) : (
-          <div className="bg-white border border-[#101010]/10 p-12 text-center">
-            <Wallet className="h-12 w-12 text-[#101010]/40 mx-auto mb-6" />
-            <h2 className="font-serif text-[36px] leading-[1.1] text-[#101010] mb-3">
-              Activate Savings Account
-            </h2>
-            <p className="text-[16px] text-[#101010]/70 mb-8 max-w-[400px] mx-auto">
-              Start earning up to 8% APY on your business funds.
-            </p>
-            <OpenSavingsAccountButton safeAddress={safeAddress || undefined} />
-          </div>
-        )
-      ) : (
-        <div className="space-y-12">
+      {/* Always show the full savings interface - auto-earn module is now optional */}
+      <div className="space-y-12">
           {/* Portfolio Overview - Grid Layout */}
           <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_1fr]">
             <CheckingActionsCard
@@ -1802,9 +1705,8 @@ export default function SavingsPageWrapper({
               </div>
             </div>
           )}
-          
+
         </div>
-      )}
     </div>
   );
 }

--- a/packages/web/src/hooks/use-primary-account-setup.ts
+++ b/packages/web/src/hooks/use-primary-account-setup.ts
@@ -62,11 +62,6 @@ const INITIAL_PROGRESS: SetupProgressItem[] = [
     label: 'Deploying your primary account',
     status: 'pending',
   },
-  {
-    step: 'savings',
-    label: 'Activating your savings automation',
-    status: 'pending',
-  },
 ];
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -271,6 +266,9 @@ export function usePrimaryAccountSetup() {
     [waitForSmartWalletClient],
   );
 
+  // NOTE: activateSavings is preserved for future use with FluidKey integration
+  // Currently not called during onboarding - users can manually deposit/withdraw
+  // without auto-earn module activation
   const activateSavings = useCallback(
     async (safeAddress: Address) => {
       updateStep('savings', {
@@ -409,7 +407,8 @@ export function usePrimaryAccountSetup() {
       const ownerAddress = await ensureSmartWallet();
       const safeAddress = await ensurePrimarySafe(ownerAddress);
 
-      await activateSavings(safeAddress);
+      // Skip auto-earn module activation for now
+      // await activateSavings(safeAddress);
 
       setResult({ safeAddress });
       return { safeAddress };
@@ -430,7 +429,7 @@ export function usePrimaryAccountSetup() {
     } finally {
       setIsRunning(false);
     }
-  }, [activateSavings, ensurePrimarySafe, ensureSmartWallet]);
+  }, [ensurePrimarySafe, ensureSmartWallet]);
 
   return {
     progress,


### PR DESCRIPTION
## Summary
Makes the auto-earn module optional for new users during onboarding. Users can now manually deposit/withdraw funds without needing to activate the auto-earn module first.

## Changes Made

### Backend/Hook Changes
- **`use-primary-account-setup.ts`**:
  - Removed the 'savings' step from `INITIAL_PROGRESS` array
  - Commented out the `activateSavings()` call in `runSetup()`
  - Preserved `activateSavings` function with documentation for future FluidKey integration
  - Updated dependency array to remove unused `activateSavings`

### Frontend Changes
- **`page-wrapper.tsx`**:
  - Removed conditional rendering based on `isEarnModuleInitialized`
  - Now shows full savings interface (deposit/withdraw) regardless of module activation status
  - Removed activation UI that was blocking users from accessing manual deposit/withdraw

## Why These Changes?

1. **Simplifies Onboarding**: New users no longer need to wait for auto-earn module activation
2. **Manual Control**: Users can immediately deposit/withdraw funds manually
3. **Future-Ready**: Infrastructure preserved for re-enabling auto-earn via FluidKey later
4. **Backward Compatible**: Existing users with activated auto-earn module continue to work normally

## Testing

✅ TypeScript compilation passes  
✅ Build succeeds  
✅ Onboarding flow only deploys Safe (no module activation)  
✅ Savings page accessible immediately after Safe deployment  
✅ Manual deposit/withdraw functionality available without module

## Migration Notes

- **New Users**: Will skip auto-earn activation, can use manual deposit/withdraw immediately
- **Existing Users**: No impact - their activated modules continue to work
- **Future**: `activateSavings` function preserved for FluidKey integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>